### PR TITLE
feat: create multiple sa with roles in one each own module blocks

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -27,8 +27,8 @@ module "terraform-service-account" {
 module "terraform-service-account-role" {
   source = "../service-account-role"
 
-  project_id            = module.project.id
-  service_accounts       = [
+  project_id = module.project.id
+  service_accounts = [
     {
       email = module.terraform-service-account.emails["${var.account_id}"]
       roles = var.roles

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -30,7 +30,7 @@ module "terraform-service-account-role" {
   project_id = module.project.id
   service_accounts = [
     {
-      email = module.terraform-service-account.emails["${var.account_id}"]
+      email = module.terraform-service-account.emails[var.account_id]
       roles = var.roles
     }
   ]
@@ -39,7 +39,7 @@ module "terraform-service-account-role" {
 }
 
 resource "google_service_account_key" "sa_key" {
-  service_account_id = module.terraform-service-account.names["${var.account_id}"]
+  service_account_id = module.terraform-service-account.names[var.account_id]
   private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
 
   depends_on = [module.terraform-service-account-role]

--- a/modules/service-account-role/main.tf
+++ b/modules/service-account-role/main.tf
@@ -1,7 +1,16 @@
-resource "google_project_iam_member" "roles" {
-  for_each = toset(var.roles)
+resource "google_project_iam_member" "bindings" {
+  for_each = {
+    for sa in flatten([
+      for account in var.service_accounts : [
+        for role in account.roles : {
+          email = account.email
+          role  = role
+        }
+      ]
+    ]) : "${sa.email}_${sa.role}" => sa
+  }
 
   project = var.project_id
-  role    = each.value
-  member  = "serviceAccount:${var.service_account_email}"
+  role    = each.value.role
+  member  = "serviceAccount:${each.value.email}"
 }

--- a/modules/service-account-role/variables.tf
+++ b/modules/service-account-role/variables.tf
@@ -3,12 +3,11 @@ variable "project_id" {
   type        = string
 }
 
-variable "roles" {
-  description = "A list of roles to assign to the service account."
-  type        = list(string)
-}
 
-variable "service_account_email" {
-  description = "The email of the service account to which the roles will be assigned."
-  type        = string
+variable "service_accounts" {
+  description = "The service account object containing account_id, display_name, description, and project_id."
+  type = list(object({
+    email = string
+    roles = list(string)
+  }))
 }

--- a/modules/service-account/main.tf
+++ b/modules/service-account/main.tf
@@ -1,6 +1,7 @@
 resource "google_service_account" "service_account" {
-  account_id   = var.account_id
-  display_name = var.display_name
-  description  = var.description
-  project      = var.project_id
+  for_each     = { for sa in var.service_accounts : sa.account_id => sa }
+  account_id   = each.value.account_id
+  display_name = each.value.display_name
+  description  = each.value.description
+  project      = each.value.project_id
 }

--- a/modules/service-account/output.tf
+++ b/modules/service-account/output.tf
@@ -1,9 +1,15 @@
-output "name" {
-  description = "The name of the service account."
-  value       = google_service_account.service_account.name
+output "emails" {
+  description = "Email addresses of the created service accounts"
+  value       = {
+    for k, sa in google_service_account.service_account :
+    k => sa.email
+  }
 }
 
-output "email" {
-  description = "The email of the service account."
-  value       = google_service_account.service_account.email
+output "names" {
+  description = "Names of the created service accounts"
+  value       = {
+    for k, sa in google_service_account.service_account :
+    k => sa.name
+  }
 }

--- a/modules/service-account/output.tf
+++ b/modules/service-account/output.tf
@@ -1,6 +1,6 @@
 output "emails" {
   description = "Email addresses of the created service accounts"
-  value       = {
+  value = {
     for k, sa in google_service_account.service_account :
     k => sa.email
   }
@@ -8,7 +8,7 @@ output "emails" {
 
 output "names" {
   description = "Names of the created service accounts"
-  value       = {
+  value = {
     for k, sa in google_service_account.service_account :
     k => sa.name
   }

--- a/modules/service-account/variables.tf
+++ b/modules/service-account/variables.tf
@@ -1,21 +1,9 @@
-variable "account_id" {
-  description = "The ID of the service account."
-  type        = string
+variable "service_accounts" {
+  description = "List of service accounts to create"
+  type = list(object({
+    account_id   = string
+    display_name = string
+    description  = string
+    project_id   = string
+  }))
 }
-
-variable "display_name" {
-  description = "The display name of the service account."
-  type        = string
-  default     = ""
-}
-
-variable "description" {
-  description = "A description of the service account."
-  type        = string
-  default     = ""
-}
-
-variable "project_id" {
-  description = "The ID of the project where the service account will be created."
-  type        = string
-}   


### PR DESCRIPTION
This PR makes it possbile in both service account and service roles module to create multiple roles and sa in an list with objects